### PR TITLE
use .andWhere to permit pre-filtering

### DIFF
--- a/src/lib/executeQuery.ts
+++ b/src/lib/executeQuery.ts
@@ -62,7 +62,7 @@ const executeQueryByQueryBuilder = async (inputQueryBuilder, query, options: any
 
   let queryBuilder = inputQueryBuilder;
   queryBuilder = queryBuilder
-    .where(odataQuery.where)
+    .andWhere(odataQuery.where)
     .setParameters(mapToObject(odataQuery.parameters));
 
   if (odataQuery.select && odataQuery.select != '*') {


### PR DESCRIPTION
Hi,

Thanks for starting this project, I have found it very useful.

I was trying to pre-filter a query as is described in the `README` like this:

```ts
    const queryBuilder = getRepository(User)
      .createQueryBuilder("user")
      .where("user.roleName = :roleName", { roleName: 'admin' });
    const data = await executeQuery(queryBuilder, req.query);
```

The custom `.where` clause was not getting appended to the query generate, the same thing happens when using `.andWhere` here.

The change I made to `executeQuery.ts` looks to be backwards compatible as far as I have tested, as in it has no effect if a custom `.where` clause is not used.