### PR TITLE
Fix for #25

### DIFF
--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -45,6 +45,9 @@ export class TypeOrmVisitor extends Visitor {
   }
 
   protected VisitSelectItem(node: Token, context: any) {
+    if (this.select !== "" && !this.select.trim().endsWith(",")) {
+      this.select += ", ";
+    }
     if (node.raw.includes('/')) {
       const item = node.raw.replace(/\//g, '.');
       this.select += item;


### PR DESCRIPTION
Fixes #25 

Sometimes, `this.select` might not start as a blank slate. In the broken example given in the issue page, `author.id` was already occupying `this.select`, and thus new fields were simply being appended. This ensures that if we have data in `this.select` that doesn't end in `,`, we add it manually.

 I have no idea if this is a proper fix. Honestly it seems a bit janky, but I don't see how it would interfere negatively with anything else - if we have something in `this.select` at the beginning of this method we would always want it to end in `,`.

Might I suggest finding a way to move toward storing these things in an array, and then doing a join() when we need to produce? That would avoid doing all this string manipulation which always makes me nervous. Although I don't know how well that would play with the base class. 

## Testing

* Pull current master 9985f6c
* Start example server
* Navigate to `http://localhost:3001/api/posts?$skip=0&$top=10&$filter=author/id eq 1&$expand=author($select=id)&$select=id,title,text`

### Pre-fix:
Before, this would return a 500 error 
```
{
    "message": "Internal server error.",
    "error": {
        "message": "SQLITE_ERROR: no such column: author.idPost.id"
    }
}
```

This is due to not handling concatenation of selects properly, and produces the following SQL query
```
SELECT DISTINCT "distinctAlias"."post_id" AS "ids_Post_id"
FROM   (SELECT "Post"."title" AS "Post_title",
               "Post"."text"  AS "Post_text",
               author.idpost.id
        FROM   "posts" "Post"
               LEFT JOIN "authors" "author"
                      ON "author"."id" = "Post"."author_id"
                         AND ( 1 = 1 )
        WHERE  "author"."id" = ?) "distinctAlias"
ORDER  BY "post_id" ASC
LIMIT  10 
```

Note the `author.idpost.id`

### Post-fix
With this PR applied, it now returns correctly
```
[
    {
        "id": 1,
        "title": "Ultricies Sem Ltd",
        "text": "quam. Curabitur vel lectus. Cum",
        "author": {
            "id": 1
        }
    },
    {
        "id": 6,
        "title": "Nunc Interdum Feugiat LLC",
        "text": "elit, pellentesque a, facilisis non, bibendum sed, est.",
        "author": {
            "id": 1
        }
    }
]
```
