### PR TITLE
Fix for #24

### DIFF
--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -1,11 +1,12 @@
-import {Token} from 'odata-v4-parser/lib/lexer';
+import {Token, TokenType} from 'odata-v4-parser/lib/lexer';
 import {Literal} from 'odata-v4-literal';
 import {SQLLiteral, SQLLang, Visitor} from 'odata-v4-sql/lib/visitor';
 
 export class TypeOrmVisitor extends Visitor {
   includes: TypeOrmVisitor[] = [];
   alias: string = '';
-
+  // all other ones are sorted at the front
+  private queryOptionsSort = [TokenType.Select, TokenType.Expand, TokenType.Filter]
   private expands: {[key: string]: string} = {};
 
   constructor(options) {
@@ -22,6 +23,12 @@ export class TypeOrmVisitor extends Visitor {
       sql += ` FETCH NEXT ${this.limit} ROWS ONLY`;
     }
     return sql;
+  }
+
+  proected VisitQueryOptions(node: Token, context: any) {
+    node.value.options
+      .sort((a:Token, b: Token)=>this.queryOptionsSort.indexOf(a.type) - this.queryOptionsSort.indexOf(b.type))
+      .forEach((option) => this.Visit(option, context));
   }
 
   protected VisitExpand(node: Token, context: any) {
@@ -62,6 +69,8 @@ export class TypeOrmVisitor extends Visitor {
 
   protected VisitPropertyPathExpression(node: Token, context: any) {
     if (context.target === 'where' && node.value.current) {
+      // if we're in a filtering context and get to this poinrt, we're dealing with a `relation/member`
+      // We need to ensure that this relation is loaded into a Visitor
       let expandPath = node.value.current.value.name;
       let visitor = this.includes.filter(
         (v) => v.navigationProperty == expandPath
@@ -71,12 +80,15 @@ export class TypeOrmVisitor extends Visitor {
         visitor.parameterSeed = this.parameterSeed;
         this.includes.push(visitor);
         visitor.Visit(node.value.current);
+        // if the visitor never existed before, that means the relation hasn't been loaded with another Token. 
+        // It's only used for filtering data, and thus doesn't need to return extra data
         visitor.where = '1 = 1';
         visitor.select = '';
         visitor.navigationProperty = expandPath;
       }
     }
 
+    // Default implementation
     if (node.value.current && node.value.next) {
       this.Visit(node.value.current, context);
       context.identifier += '.';


### PR DESCRIPTION
Fixes #24 

I really don't know if this is the proper way of doing things, but it seems to work (at least for my simple test cases).

This PR addresses the issue noted in #24, which is that you cannot filter by a relation without also expanding it. According to the odata spec, it seems that if you provide `$expand`, then you MUST provide the properties (which can be limited via `expand($select=))`. However, filtering doesn't seem to inherently need the expansion according to the spec, and I tested that using a couple public odata providers (northwind comes to mind).

The reason it was required to be expanded was due to the fact that the joins are handled by the `visitor.includes` property, and this is only populated when the Expand node is reached.

I tweaked the `VisitPropertyPathExpression` node while in a filter (which, to the best that I can tell, allows us to find relation filters) to also stick the relation in the includes. I also hardcode the select to empty string and where to 1=1 (these were setting incorrect values). Due to this tho, I had to also add a sort to the `QueryOptions` to ensure expand is evaluated before filter, otherwise if filter is processed first and added `posts`, for example, to `includes`, and then we process the expand(posts), it's would have incorrect selection.

Personally, I think it might be a good idea to, instead of trying to add the filter to the includes, create a new property just for those relations that need to be loaded but not selected from. But Still getting used to the codebase. Might tackle that one in the future.

I have not tested heavily (and it's a shame there aren't unit tests). But the provided server examples are  running as they were previously

## Testing

### Pre-fix

`{{base_url}}/api/authors?$filter=posts/id eq 3&$select=id,name`

Doesn't work due to no `$expand`, thus no join to Posts, thus `posts.id` is an invalid filter

```
{
    "message": "Internal server error.",
    "error": {
        "message": "SQLITE_ERROR: no such column: posts.id"
    }
}
```

### Post-fix

`{{base_url}}/api/authors?$filter=posts/id eq 3&$select=id,name`

```
[
    {
        "id": 3,
        "name": "Maggy Juarez"
    }
]
```

### Other tests

The tests below simply show that the other routs should work as they did before

`{{base_url}}/api/authors?$filter=posts/id eq 3&$expand=posts&$select=id,name`
```
[
    {
        "id": 3,
        "name": "Maggy Juarez",
        "posts": [
            {
                "id": 3,
                "title": "Feugiat Associates",
                "text": "tincidunt. Donec vitae erat"
            }
        ]
    }
]
```

`{{base_url}}/api/authors?$filter=posts/id eq 3&$expand=posts($select=text,id)&$select=id,name`
```
[
    {
        "id": 3,
        "name": "Maggy Juarez",
        "posts": [
            {
                "id": 3,
                "text": "tincidunt. Donec vitae erat"
            }
        ]
    }
]
```

`{{base_url}}/api/authors?$filter=posts/id eq 3&$expand=posts($select=text,id)&$select=id,name,posts/title`
```
[
    {
        "id": 3,
        "name": "Maggy Juarez",
        "posts": [
            {
                "id": 3,
                "title": "Feugiat Associates",
                "text": "tincidunt. Donec vitae erat"
            }
        ]
    }
]
```
