### PR TITLE
Fixes #29

### DIFF
--- a/examples/server/src/entities/author.ts
+++ b/examples/server/src/entities/author.ts
@@ -1,5 +1,6 @@
-import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
+import {Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
 import {Post} from './post';
+import {User} from './user';
 
 @Entity('authors')
 export class Author {
@@ -13,4 +14,6 @@ export class Author {
   @OneToMany(type => Post, post => post.author)
   posts: Post[];
 
+  @ManyToOne(type => User)
+  user: User;
 }

--- a/examples/server/src/entities/post.ts
+++ b/examples/server/src/entities/post.ts
@@ -1,7 +1,8 @@
-import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import {Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
 import {PostDetails} from './postDetails';
 import {PostCategory} from './postCategory';
 import {Author} from './author';
+import { PostComment } from './postComment';
 
 @Entity('posts')
 export class Post {
@@ -32,4 +33,6 @@ export class Post {
   @ManyToOne(type => Author, author => author.posts)
   author: Author;
 
+  @OneToMany(type => PostComment, comment => comment.post)
+  comments: PostComment;
 }

--- a/examples/server/src/entities/postComment.ts
+++ b/examples/server/src/entities/postComment.ts
@@ -1,0 +1,22 @@
+import {Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
+import {Post} from './post';
+import { User } from './user';
+
+@Entity('post_comments')
+export class PostComment {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    type: String,
+    nullable: true
+  })
+  comment: string | null;
+
+  @ManyToOne(type => User)
+  user: User
+
+  @ManyToOne(type => Post, post => post.comments)
+  post: Post;
+}

--- a/examples/server/src/entities/user.ts
+++ b/examples/server/src/entities/user.ts
@@ -1,0 +1,11 @@
+import {Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn} from 'typeorm';
+
+@Entity('users')
+export class User {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  username: string;
+}

--- a/examples/server/src/migrations/1577087002356-dataFilling.ts
+++ b/examples/server/src/migrations/1577087002356-dataFilling.ts
@@ -3,13 +3,23 @@ import {MigrationInterface, QueryRunner} from 'typeorm';
 export class DataFilling1577087002356 implements MigrationInterface {
 
   async up(queryRunner: QueryRunner): Promise<any> {
-    await queryRunner.query(`INSERT INTO "authors" (id,name) 
+    await queryRunner.query(`INSERT INTO "users" (id,username) 
+                                  VALUES 
+                                    (1,'a_manning_ursula'),
+                                    (2,'a_butler_carly'),
+                                    (3,'a_juarez_maggy'),
+                                    (4,'a_murray_colette'),
+                                    (5,'a_salinas_emmanuel'),
+                                    (6,'user_1'),
+                                    (7,'user_2'),
+                                    (8,'user_3')`)
+    await queryRunner.query(`INSERT INTO "authors" (id,name,user_id) 
                                     VALUES 
-                                      (1,'Ursula Manning'),
-                                      (2,'Carly Butler'),
-                                      (3,'Maggy Juarez'),
-                                      (4,'Colette Murray'),
-                                      (5,'Emmanuel Salinas')`);
+                                      (1,'Ursula Manning',1),
+                                      (2,'Carly Butler',2),
+                                      (3,'Maggy Juarez',3),
+                                      (4,'Colette Murray',4),
+                                      (5,'Emmanuel Salinas',5)`);
     await queryRunner.query(`INSERT INTO "post_category" (id,name) 
                                     VALUES 
                                       (1,'Eu Nulla Limited'),
@@ -29,6 +39,14 @@ export class DataFilling1577087002356 implements MigrationInterface {
                                       (8,'In Hendrerit Consectetuer Foundation','vulputate, nisi sem semper erat,',3,3),
                                       (9,'Odio Aliquam Vulputate Foundation','velit eget',4,4),
                                       (10,'Cursus Ltd','ac mattis ornare, lectus ante dictum mi, ac mattis velit',5,5)`);
+    await queryRunner.query(`INSERT INTO "post_comments" (id,comment,user_id,post_id) 
+                                      VALUES 
+                                        (1,'Nulla nec feugiat metus, ut condimentum nisi. Vestibulum ac velit.',6,1),
+                                        (2,'In consequat at neque pharetra rutrum. Curabitur rutrum mi sem.',6,1),
+                                        (3,'Nulla facilisi. Cras vestibulum dictum dui bibendum maximus. Nullam eu.',8,1),
+                                        (4,'Pellentesque habitant morbi tristique senectus et netus et malesuada fames.',7,1),
+                                        (5,'Sed rutrum pretium nunc nec condimentum. Proin non orci imperdiet.',6,1)`);                              
+
   }
 
   async down(queryRunner: QueryRunner): Promise<any> {

--- a/examples/server/src/server.ts
+++ b/examples/server/src/server.ts
@@ -6,6 +6,8 @@ import {Author} from './entities/author';
 import {Post} from './entities/post';
 import {PostCategory} from './entities/postCategory';
 import {PostDetails} from './entities/postDetails';
+import { PostComment } from './entities/postComment';
+import { User } from './entities/user';
 import {DataFilling1577087002356} from './migrations/1577087002356-dataFilling';
 import {createConnection} from './db/createConnection';
 import config from './config';
@@ -17,7 +19,9 @@ export default (async () => {
       Author,
       Post,
       PostCategory,
-      PostDetails
+      PostComment,
+      PostDetails,
+      User
     ], [DataFilling1577087002356], dbConfig);
 
     const app = express();

--- a/src/lib/executeQuery.ts
+++ b/src/lib/executeQuery.ts
@@ -29,7 +29,7 @@ const processIncludes = (queryBuilder: any, odataQuery: any, alias: string) => {
       const join = item.select === '*' ? 'leftJoinAndSelect' : 'leftJoin';
       queryBuilder = queryBuilder[join](
         (alias ? alias + '.' : '') + item.navigationProperty,
-        item.navigationProperty,
+        item.alias,
         item.where.replace(/typeorm_query/g, item.navigationProperty),
         mapToObject(item.parameters)
       );
@@ -42,7 +42,7 @@ const processIncludes = (queryBuilder: any, odataQuery: any, alias: string) => {
       }
 
       if (item.includes && item.includes.length > 0) {
-        processIncludes(queryBuilder, {includes: item.includes}, item.navigationProperty);
+        processIncludes(queryBuilder, {includes: item.includes}, item.alias);
       }
     });
   }
@@ -66,7 +66,7 @@ const executeQueryByQueryBuilder = async (inputQueryBuilder, query, options: any
     .andWhere(odataQuery.where)
     .setParameters(mapToObject(odataQuery.parameters));
 
-  if (odataQuery.select && odataQuery.select != '*') {
+  if (odataQuery. select && odataQuery.select != '*') {
     queryBuilder = queryBuilder.select(odataQuery.select.split(',').map(i => i.trim()));
   }
 

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -30,10 +30,9 @@ export class TypeOrmVisitor extends Visitor {
       .sort((a:Token, b: Token)=>this.queryOptionsSort.indexOf(a.type) - this.queryOptionsSort.indexOf(b.type))
       .forEach((option) => this.Visit(option, context));
   }
-
   protected VisitExpand(node: Token, context: any) {
     node.value.items.forEach((item) => {
-      let expandPath = item.value.path.raw;
+      let expandPath = item.value.path.raw + item.position;
       let visitor = this.includes.filter(v => v.navigationProperty == expandPath)[0];
       if (!visitor) {
         visitor = new TypeOrmVisitor({...this.options, alias: expandPath});

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -6,8 +6,7 @@ export class TypeOrmVisitor extends Visitor {
   includes: TypeOrmVisitor[] = [];
   alias: string = '';
   // all other ones are sorted at the front
-  private queryOptionsSort = [TokenType.Select, TokenType.Expand, TokenType.Filter]
-  private expands: {[key: string]: string} = {};
+  private queryOptionsSort = [TokenType.Expand, TokenType.Filter, TokenType.Select]
 
   constructor(options) {
     super(options);
@@ -43,8 +42,6 @@ export class TypeOrmVisitor extends Visitor {
 
       if (visitor.select && visitor.select !== '*') {
         this.select += ((this.select && !this.select.trim().endsWith(',') ? ',' : '') + visitor.select);
-      } else if (this.expands[expandPath]) {
-        visitor.select = this.expands[expandPath];
       }
       this.parameterSeed = visitor.parameterSeed;
     });
@@ -52,18 +49,16 @@ export class TypeOrmVisitor extends Visitor {
 
   protected VisitSelectItem(node: Token, context: any) {
     if (node.raw.includes('/')) {
-      const item = node.raw.replace(/\//g, '.');
-      this.select += item;
-      const itemSplit = item.split('.');
+      const itemSplit = node.raw.split('/');
       const itemName = itemSplit[0];
-      this.expands[itemName] = this.expands[itemName] || '';
-      this.expands[itemName] +=
-        ((this.expands[itemName] && !this.expands[itemName].trim().endsWith(',') ? ',' : '') + item);
+      const alias = this.includes.find(x=>x.navigationProperty === itemName).alias;
+      this.select += `${alias}.${itemSplit[1]}`;
       return;
     }
 
     let item = node.raw.replace(/\//g, '.');
-    this.select += this.getIdentifier(item, context.identifier);
+    
+    this.select += ((this.select && !this.select.trim().endsWith(',') ? ',' : '') + this.getIdentifier(item, context.identifier));
   }
 
   protected VisitPropertyPathExpression(node: Token, context: any) {

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -1,11 +1,12 @@
-import {Token} from 'odata-v4-parser/lib/lexer';
+import {Token, TokenType} from 'odata-v4-parser/lib/lexer';
 import {Literal} from 'odata-v4-literal';
 import {SQLLiteral, SQLLang, Visitor} from 'odata-v4-sql/lib/visitor';
 
 export class TypeOrmVisitor extends Visitor {
   includes: TypeOrmVisitor[] = [];
   alias: string = '';
-
+  // all other ones are sorted at the front
+  private queryOptionsSort = [TokenType.Select, TokenType.Expand, TokenType.Filter]
   private expands: {[key: string]: string} = {};
 
   constructor(options) {
@@ -22,6 +23,12 @@ export class TypeOrmVisitor extends Visitor {
       sql += ` FETCH NEXT ${this.limit} ROWS ONLY`;
     }
     return sql;
+  }
+
+  proected VisitQueryOptions(node: Token, context: any) {
+    node.value.options
+      .sort((a:Token, b: Token)=>this.queryOptionsSort.indexOf(a.type) - this.queryOptionsSort.indexOf(b.type))
+      .forEach((option) => this.Visit(option, context));
   }
 
   protected VisitExpand(node: Token, context: any) {
@@ -62,6 +69,8 @@ export class TypeOrmVisitor extends Visitor {
 
   protected VisitPropertyPathExpression(node: Token, context: any) {
     if (context.target === 'where' && node.value.current) {
+      // if we're in a filtering context and get to this poinrt, we're dealing with a `relation/member`
+      // We need to ensure that this relation is loaded into a Visitor
       let expandPath = node.value.current.value.name;
       let visitor = this.includes.filter(
         (v) => v.navigationProperty == expandPath
@@ -71,12 +80,15 @@ export class TypeOrmVisitor extends Visitor {
         visitor.parameterSeed = this.parameterSeed;
         this.includes.push(visitor);
         visitor.Visit(node.value.current);
+        // if the visitor never existed before, that means the relation hasn't been loaded with another Token. 
+        // It's only used for filtering data, and thus doesn't need to return extra data
         visitor.where = '1 = 1';
         visitor.select = '';
         visitor.navigationProperty = expandPath;
       }
     }
 
+    // Default implementation
     if (node.value.current && node.value.next) {
       this.Visit(node.value.current, context);
       context.identifier += '.';


### PR DESCRIPTION
Fixes #29, Requires #28 as I used it's sorted evaluation.

Essentially, this changes the way alias's work. We no longer assume the alias = the navigation property, because in that scenerio you can't join two two or more of the same table. This PR changes the alias to be the property, plus the current position of the token, which should make them all unique since tokens can't share the same position, and it also gives helpful debugging information right there in the alias name.

Also fixes an issue with having a `,` missed.

Unfortunately, I don't really have a good test of this at the moment. I used my own test entities, but it doesn't make sense in this repo. I will try to add actual test cases to the example server.

Additionally, it's getting harder to split these changes up into PR's from my other improvements. I would love to continue to contribute, but if this project is no longer maintained, then please mention that on the README and I won't have to make the effort. But as it stands now, I might not be able to continue to move forward with additional PRs without them stepping on one another

## Testing

* Pull master 9985f6c8802a1a0031fa816e458360caeb14b753
* Cherry pick `d27b91` from this PR. This will give you new entities configured in a way that will show this problem
* Run pre-fix
* checkout PR's HEAD
* Run post-fix

The new entities are: User, and PostComment. A post has several comments, and each comment is associated with a User. Additionally, the Author now is associated with a User.

### Pre-fix
Start the example server with the new entities and migration, and then run this:
`{{base_url}}/api/posts?$select=id,title&$expand=author($expand=user),comments($expand=user)&$filter=id eq 1`

```
{
    "message": "Internal server error.",
    "error": {
        "message": "SQLITE_ERROR: ambiguous column name: user.id"
    }
}
```

This is because we're trying to expand a `user` property twice - once in `author`, and once in `comments`. Since we use the property path as the alias, there's two joins with the alias of `user`

### Post-fix

We can now bring back user relations for both author and all the comments. This is because we change the alias that is used to be unique to that specific expansion

`{{base_url}}/api/posts?$select=id,title&$expand=author($expand=user),comments($expand=user)&$filter=id eq 1`

```
[
    {
        "id": 1,
        "title": "Ultricies Sem Ltd",
        "author": {
            "id": 1,
            "name": "Ursula Manning",
            "user": {
                "id": 1,
                "username": "a_manning_ursula"
            }
        },
        "comments": [
            {
                "id": 1,
                "comment": "Nulla nec feugiat metus, ut condimentum nisi. Vestibulum ac velit.",
                "user": {
                    "id": 6,
                    "username": "user_1"
                }
            },
            {
                "id": 2,
                "comment": "In consequat at neque pharetra rutrum. Curabitur rutrum mi sem.",
                "user": {
                    "id": 6,
                    "username": "user_1"
                }
            },
            {
                "id": 3,
                "comment": "Nulla facilisi. Cras vestibulum dictum dui bibendum maximus. Nullam eu.",
                "user": {
                    "id": 8,
                    "username": "user_3"
                }
            },
            {
                "id": 4,
                "comment": "Pellentesque habitant morbi tristique senectus et netus et malesuada fames.",
                "user": {
                    "id": 7,
                    "username": "user_2"
                }
            },
            {
                "id": 5,
                "comment": "Sed rutrum pretium nunc nec condimentum. Proin non orci imperdiet.",
                "user": {
                    "id": 6,
                    "username": "user_1"
                }
            }
        ]
    }
]
```