### PR TITLE
Fix for #30

### DIFF
--- a/src/lib/executeQuery.ts
+++ b/src/lib/executeQuery.ts
@@ -31,7 +31,7 @@ const processIncludes = (queryBuilder: any, odataQuery: any, alias: string, pare
       if (join === 'leftJoin') {
         // add selections of data
         // todo: remove columns that are isSelect: false
-        queryBuilder.addSelect(item.select.split(',').map(x=>x.trim()));
+        queryBuilder.addSelect(item.select.split(',').map(x => x.trim()).filter(x => x !== ''));
       }
 
       queryBuilder = queryBuilder[join](

--- a/src/lib/executeQuery.ts
+++ b/src/lib/executeQuery.ts
@@ -23,10 +23,17 @@ const queryToOdataString = (query): string => {
   return result;
 };
 
-const processIncludes = (queryBuilder: any, odataQuery: any, alias: string) => {
+const processIncludes = (queryBuilder: any, odataQuery: any, alias: string, parent_metadata: any): [any, string] =>  {
   if (odataQuery.includes && odataQuery.includes.length > 0) {
     odataQuery.includes.forEach(item => {
+      const relation_metadata = queryBuilder.connection.getMetadata(parent_metadata.relations.find(x=>x.propertyPath === item.navigationProperty).type)
       const join = item.select === '*' ? 'leftJoinAndSelect' : 'leftJoin';
+      if (join === 'leftJoin') {
+        // add selections of data
+        // todo: remove columns that are isSelect: false
+        queryBuilder.addSelect(item.select.split(',').map(x=>x.trim()));
+      }
+
       queryBuilder = queryBuilder[join](
         (alias ? alias + '.' : '') + item.navigationProperty,
         item.navigationProperty,
@@ -42,7 +49,7 @@ const processIncludes = (queryBuilder: any, odataQuery: any, alias: string) => {
       }
 
       if (item.includes && item.includes.length > 0) {
-        processIncludes(queryBuilder, {includes: item.includes}, item.navigationProperty);
+        processIncludes(queryBuilder, {includes: item.includes}, item.alias, relation_metadata);
       }
     });
   }
@@ -60,17 +67,26 @@ const executeQueryByQueryBuilder = async (inputQueryBuilder, query, options: any
       odataQuery = createQuery(odataString, {alias: alias});
     }
   }
-
+  
   let queryBuilder = inputQueryBuilder;
+  const metadata = inputQueryBuilder.connection.getMetadata(odataQuery.alias);
+  let root_select = []
+
+  // unlike the relations which are done via leftJoin[AndSelect](), we must explicitly add root
+  // entity fields to the selection if it hasn't been narrowed down by the user.
+  if (odataQuery.select === '*') {
+    root_select = metadata.nonVirtualColumns.map(x=>`${odataQuery.alias}.${x.propertyPath}`);
+  } else {
+    root_select = odataQuery.select.split(',').map(x=>x.trim())
+  }
+
+  queryBuilder = queryBuilder.select(root_select);
+
   queryBuilder = queryBuilder
     .andWhere(odataQuery.where)
     .setParameters(mapToObject(odataQuery.parameters));
 
-  if (odataQuery.select && odataQuery.select != '*') {
-    queryBuilder = queryBuilder.select(odataQuery.select.split(',').map(i => i.trim()));
-  }
-
-  queryBuilder = processIncludes(queryBuilder, odataQuery, alias);
+  queryBuilder = processIncludes(queryBuilder, odataQuery, alias, metadata);
 
   if (odataQuery.orderby && odataQuery.orderby !== '1') {
     const orders = odataQuery.orderby.split(',').map(i => i.trim());

--- a/src/lib/executeQuery.ts
+++ b/src/lib/executeQuery.ts
@@ -1,4 +1,4 @@
-import {createQuery} from './createQuery';
+import { createQuery } from './createQuery';
 
 const mapToObject = (aMap) => {
   const obj = {};
@@ -23,10 +23,10 @@ const queryToOdataString = (query): string => {
   return result;
 };
 
-const processIncludes = (queryBuilder: any, odataQuery: any, alias: string, parent_metadata: any): [any, string] =>  {
+const processIncludes = (queryBuilder: any, odataQuery: any, alias: string, parent_metadata: any): [any, string] => {
   if (odataQuery.includes && odataQuery.includes.length > 0) {
     odataQuery.includes.forEach(item => {
-      const relation_metadata = queryBuilder.connection.getMetadata(parent_metadata.relations.find(x=>x.propertyPath === item.navigationProperty).type)
+      const relation_metadata = queryBuilder.connection.getMetadata(parent_metadata.relations.find(x => x.propertyPath === item.navigationProperty).type)
       const join = item.select === '*' ? 'leftJoinAndSelect' : 'leftJoin';
       if (join === 'leftJoin') {
         // add selections of data
@@ -49,7 +49,7 @@ const processIncludes = (queryBuilder: any, odataQuery: any, alias: string, pare
       }
 
       if (item.includes && item.includes.length > 0) {
-        processIncludes(queryBuilder, {includes: item.includes}, item.alias, relation_metadata);
+        processIncludes(queryBuilder, { includes: item.includes }, item.alias, relation_metadata);
       }
     });
   }
@@ -64,20 +64,20 @@ const executeQueryByQueryBuilder = async (inputQueryBuilder, query, options: any
   if (query) {
     const odataString = queryToOdataString(query);
     if (odataString) {
-      odataQuery = createQuery(odataString, {alias: alias});
+      odataQuery = createQuery(odataString, { alias: alias });
     }
   }
-  
+
   let queryBuilder = inputQueryBuilder;
-  const metadata = inputQueryBuilder.connection.getMetadata(odataQuery.alias);
+  const metadata = inputQueryBuilder.connection.getMetadata(alias);
   let root_select = []
 
   // unlike the relations which are done via leftJoin[AndSelect](), we must explicitly add root
   // entity fields to the selection if it hasn't been narrowed down by the user.
-  if (odataQuery.select === '*') {
-    root_select = metadata.nonVirtualColumns.map(x=>`${odataQuery.alias}.${x.propertyPath}`);
+  if (Object.keys(odataQuery).length === 0 || odataQuery.select === '*') {
+    root_select = metadata.nonVirtualColumns.map(x => `${alias}.${x.propertyPath}`);
   } else {
-    root_select = odataQuery.select.split(',').map(x=>x.trim())
+    root_select = odataQuery.select.split(',').map(x => x.trim())
   }
 
   queryBuilder = queryBuilder.select(root_select);
@@ -111,7 +111,7 @@ const executeQueryByQueryBuilder = async (inputQueryBuilder, query, options: any
 
 const executeQuery = async (repositoryOrQueryBuilder: any, query, options: any) => {
   options = options || {};
-  const alias =  options.alias || '';
+  const alias = options.alias || '';
   let queryBuilder = null;
 
   // check that input object is query builder
@@ -120,8 +120,8 @@ const executeQuery = async (repositoryOrQueryBuilder: any, query, options: any) 
   } else {
     queryBuilder = repositoryOrQueryBuilder.createQueryBuilder(alias);
   }
-  const result = await executeQueryByQueryBuilder(queryBuilder, query, {alias});
+  const result = await executeQueryByQueryBuilder(queryBuilder, query, { alias });
   return result;
 };
 
-export {executeQuery};
+export { executeQuery };

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -34,12 +34,6 @@ export class TypeOrmVisitor extends Visitor {
         this.includes.push(visitor);
       }
       visitor.Visit(item);
-
-      if (visitor.select && visitor.select !== '*') {
-        this.select += ((this.select && !this.select.trim().endsWith(',') ? ',' : '') + visitor.select);
-      } else if (this.expands[expandPath]) {
-        visitor.select = this.expands[expandPath];
-      }
       this.parameterSeed = visitor.parameterSeed;
     });
   }


### PR DESCRIPTION
Fixes #30 

## Testing 

### Pre-fix

`{{base_url}}/api/posts?$expand=author($select=id),category`

This would return an empty result set, primarily because we're not explicitly selecting out anything for the Post.

```
[]
```

### Post-fix
`{{base_url}}/api/posts?$expand=author($select=id),category`

Produces the expected response:
```
[
    {
        "id": 1,
        "title": "Ultricies Sem Ltd",
        "text": "quam. Curabitur vel lectus. Cum",
        "author": {
            "id": 1
        },
        "category": {
            "id": 1,
            "name": "Eu Nulla Limited"
        }
    },
...
]
```