### PR TITLE
Set up easier development environment

### DIFF
--- a/examples/server/nodemon.json
+++ b/examples/server/nodemon.json
@@ -1,0 +1,6 @@
+{
+    "watch": "dist/**/*.js",
+    "execMap": {
+      "ts": "ts-node"
+    }
+  }

--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "serve": "npm run build && node --inspect dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "serve": "nodemon ./src/server.ts",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev:run": "nodemon ./src/server.ts",
+    "dev:watch": "tsc --build --watch"
   },
   "repository": {
     "type": "git",
@@ -22,8 +24,8 @@
   "dependencies": {
     "convict": "^5.2.0",
     "express": "^4.17.1",
-    "odata-v4-typeorm": "file:../..",
     "pg": "^7.14.0",
+    "sqlite3": "^5.0.2",
     "typeorm": "^0.2.21"
   },
   "devDependencies": {

--- a/examples/server/src/config.ts
+++ b/examples/server/src/config.ts
@@ -25,58 +25,6 @@ const config = convict({
       arg: 'http_port'
     }
   },
-  db: {
-    host: {
-      doc: 'Database host name/IP',
-      format: '*',
-      default: 'localhost',
-      env: 'db_host'
-    },
-    port: {
-      doc: 'Database port number',
-      format: Number,
-      default: 5432,
-      env: 'db_port'
-    },
-    database: {
-      doc: 'Database name',
-      format: String,
-      default: 'demo_ov4typeorm_posts',
-      env: 'db_database'
-    },
-    username: {
-      doc: 'Connection user name',
-      format: String,
-      default: 'postgres',
-      env: 'db_username'
-    },
-    password: {
-      doc: 'Connection user password',
-      format: String,
-      default: 'q1w2e3R4',
-      env: 'db_password'
-    },
-    name: {
-      doc: 'Connection name',
-      format: String,
-      default: 'default'
-    },
-    type: {
-      doc: 'Connection type',
-      format: String,
-      default: 'postgres'
-    },
-    synchronize: {
-      doc: 'Connection synchronize type',
-      format: Boolean,
-      default: true
-    },
-    logging: {
-      doc: 'Enable logging',
-      format: Boolean,
-      default: true
-    }
-  },
   logger: {
     level: {
       doc: 'The application logger level.',

--- a/examples/server/src/server.ts
+++ b/examples/server/src/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import {odataQuery} from 'odata-v4-typeorm';
+import {odataQuery} from '../../../';
 import {getConnection, getRepository} from 'typeorm';
 
 import {Author} from './entities/author';
@@ -9,16 +9,16 @@ import {PostDetails} from './entities/postDetails';
 import {DataFilling1577087002356} from './migrations/1577087002356-dataFilling';
 import {createConnection} from './db/createConnection';
 import config from './config';
+import * as ormconfig from './ormconfig.json'
 
 export default (async () => {
   try {
-    const dbConfig = config.db;
     await createConnection([
       Author,
       Post,
       PostCategory,
       PostDetails
-    ], [DataFilling1577087002356], dbConfig);
+    ], [DataFilling1577087002356], ormconfig);
 
     const app = express();
 

--- a/examples/server/tsconfig.json
+++ b/examples/server/tsconfig.json
@@ -5,10 +5,12 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "target": "es6",
-    "noImplicitAny": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",
+    "rootDir": "../../", 
     "baseUrl": ".",
     "paths": {
       "*": [
@@ -18,6 +20,10 @@
     }
   },
   "include": [
-    "src/**/*"
-  ]
+    "src/**/*",
+    "../../src/**/*"
+  ],
+  "references": [
+    { "path": "../../"  }
+]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "mocha": "^6.2.2",
     "odata-v4-server": "rc",
     "pg": "^6.1.0",
-    "typescript": "^2.0.6"
+    "typescript": "^3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
+    "composite": true,
     "sourceMap": true,
     "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "experimentalDecorators": true,
-    "outDir": "build"
+    "outDir": "build",
+    "rootDir": "./src", 
   },
   "include": [
     "src/**/*"
@@ -13,6 +15,5 @@
   "exclude": [
     "build",
     "node_modules",
-    "examples"
   ]
 }


### PR DESCRIPTION
This does a couple things:
* Sets up npm run scripts using nodemon to automatically restart the server upon changes
    * Sets up a TypeScript project reference in the server project so that "changes" also means any file changes to the main library. So instead of having to rebuild the main library separately to get new changes for the server, it happens automatically.
* Removes `config.db` and instead uses `ormconfig.json`. Since this seems to be a server set up for examples (and debugging), the less reliance on thirdparty configuration the better. For me to get set up, I had to look at how the config library works (admittedly it was simple, but I couldn't just copy and paste my working TypeORM config and run with it)
* Installs SQLite and uses it as the default ormconfig. This removes the requirement for the user to either get sqlite installed and configured on their own, or already have a running database service available to hook up. This basically allows a dev to get up and running very quickly without any manual config.


With these changes it's as easy as running npm install on the library and the server directly, and then running two terminals: `npm run dev:watch` and `npm run dev:run`